### PR TITLE
Use sessionKey over hard-coded "express.sid"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ function authorize(options){
 
     data.cookie = connectUtils.parseSignedCookies(parsedCookie, sessionSecret);
 
-    data.sessionID = data.cookie['express.sid'];
+    data.sessionID = data.cookie[sessionKey];
 
     sessionStore.get(data.sessionID, function(err, session){
       


### PR DESCRIPTION
The sessionKey argument was ignored and "express.sid" was always used
instead.
