### PR TITLE
Session not existing results in 500 internal server error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@ function authorize(options) {
 
   return function(data, accept){
     if (!data.headers.cookie) {
-      return accept('Session cookie required.', false);
+      return accept(null, false);
     }
 
     var parsedCookie = cookie.parse(data.headers.cookie);
@@ -48,7 +48,7 @@ function authorize(options) {
       if (err) {
         return accept('Error in session store.', false);
       } else if (!session) {
-        return accept('Session not found.', false);
+        return accept(null, false);
       }
 
       if( !session[ auth.passport._key ] ){
@@ -56,11 +56,11 @@ function authorize(options) {
       }
 
       var userKey = session[ auth.passport._key ][ auth.userProperty ];
-      
+
       if( !userKey && auth.fail ) {
         return auth.fail( data, accept );
       } else if( !userKey ) {
-        return accept('not yet authenticated', false);
+        return accept(null, false);
       }
 
       if( auth.success ) {


### PR DESCRIPTION
On various failures, accept() is called with an error as the first parameter, which socket.io takes to mean that an error occurred trying to handshake, and returns a 500 error to the client. However, in at least one case, the session not existing, this is not an "error" but actually just the user not being logged in. For example, the session may have expired (or you are using MemoryStore and restarted the server).

In these cases, it would be nice for the client to receive the "error" event rather than getting a 500 error, so that the client code could detect it and redirect the user to a login page. One simple fix is just changing lines 38 and 51 to pass null as the first parameter (or maybe just line 51).
