### PR TITLE
Improved failure reporting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,6 @@ function authorize(options) {
       if (err) {
         return auth.fail( 'Error in session store.', accept );
       } else if (!session) {
-		  console.log("Dump:", data, auth.store);
 	    return auth.fail( 'Failed to retrieve session', accept );
       }
 


### PR DESCRIPTION
I added a default for `auth.fail`, which simply calls `accept( data, false );`, and have switched to calling `auth.fail` in place of `accept` in the event of failures.

This prevents passport.socketio from failing silently (As it was in my case), and instead it always informs the user of a failure, if they've setup a `fail` handler.
