### PR TITLE
Added peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,16 +21,19 @@
   },
   "license": "MIT",
   "dependencies": {
-    "passport": "~0.1.16",
-    "connect": "2.7.5",
+    "passport": "~0.1.17",
+    "connect": "~2.7.11",
     "cookie": "0.0.5",
-    "request": "~2.19.0",
-    "xtend": "~2.0.3"
+    "request": "~2.21.0",
+    "xtend": "~2.0.5"
+  },
+  "peerDependencies": {
+    "connect": ">= 2.7"
   },
   "devDependencies": {
     "should": "~1.2.2",
     "mocha": "~1.9.0",
-    "express": "~3.1.2",
+    "express": "~3.2.6",
     "socket.io": "~0.9.14",
     "passport-local": "~0.1.6",
     "xmlhttprequest": "~1.5.0",


### PR DESCRIPTION
Not sure that I added it right. Our case requires: cookie >= 0.0.5, and cookie-signature 1.0.1. `connect` has this bundle, so I decided setup peer-deps for connect.

Also found weird bug that io.on('connect') does not fire in node 0.10.10, and our tests fails. Did not have time to go deeper at this problem. I downgraded my local node to 0.10.5 and it works fine.
