### PR TITLE
Check "data.query" exists

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,7 +35,7 @@ function authorize(options) {
 
   return function(data, accept){
     data.cookie = parseCookie(auth, data.headers.cookie || '');
-    data.sessionID = data.query.session_id || data.cookie[auth.key] || '';
+    data.sessionID = (data.query && data.query.session_id) || data.cookie[auth.key] || '';
     data[auth.userProperty] = {
       logged_in: false
     };


### PR DESCRIPTION
Check "data.query" exists before checking the data.query.session_id.
Avoid: "TypeError: Cannot read property 'session_id' of undefined "
