### PR TITLE
move to the official version of socket.io-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "socket.io": "~0.9.14",
     "passport-local": "~0.1.6",
     "xmlhttprequest": "~1.5.0",
-    "socket.io-client": "git+https://github.com/jfromaniello/socket.io-client.git",
+    "socket.io-client": "~0.9.16",
     "connect": "~2.7.11"
   }
 }


### PR DESCRIPTION
Can you move to the official version of socket.io-client?
