### PR TITLE
fix bug: use passport provided in options hash

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,6 @@ function parseCookie(auth, cookieHeader) {
 
 function authorize(options) {
   var defaults = {
-    passport:     require('passport'),
     key:          'connect.sid',
     secret:       null,
     store:        null,
@@ -26,6 +25,10 @@ function authorize(options) {
   };
 
   var auth = xtend(defaults, options);
+
+  if (!auth.passport){
+    auth.passport = require('passport');  //not added in defaults, because that would already load the other passport.
+  }
 
   auth.userProperty = auth.passport._userProperty || 'user';
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "passport": "~0.2.0",
     "xtend": "~2.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "passport": "~0.2.0",
     "xtend": "~2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
it took me several hours to figure this out: I was using passport 0.1.17, because passport-local forced me to stick with this version. Then, passport.socketio was loading passport 0.2.0, even though I had provided passport as a parameter to the options hash. It turns out that the passport: require('passport') already loads version 0.2.0 and this version does not go away.
The wrong lib caused problems, because the signature of serializeUser changed between 0.1.17 and 0.2.0.