### PR TITLE
backward-compatible support for socket.io v1.0.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,8 +21,20 @@ function authorize(options) {
     key:          'connect.sid',
     secret:       null,
     store:        null,
-    success:      function(data, accept){accept(null, true)},
-    fail:         function(data, message, critical, accept){accept(null, false)}
+    success:      function (data, accept){
+      if (data.request) {
+        accept();
+      } else {
+        accept(null, true)
+      }
+    },
+    fail:         function (data, message, critical, accept) {
+      if (data.request) {
+        accept(new Error(message));
+      } else {
+        accept(null, false)
+      }
+    }
   };
 
   var auth = xtend(defaults, options);
@@ -33,8 +45,11 @@ function authorize(options) {
     throw new Error('cookieParser is required use connect.cookieParser or express.cookieParser');
   }
 
-  return function(data, accept){
-    data.cookie = parseCookie(auth, data.headers.cookie || '');
+  return function(data, accept){ 
+    // socket.io v1.0 now provides socket handshake data via `socket.request`
+    var cookieHeader = (data.request ? data.request.headers.cookie : data.headers.cookie) || ''
+
+    data.cookie = parseCookie(auth, cookieHeader);
     data.sessionID = (data.query && data.query.session_id) || data.cookie[auth.key] || '';
     data[auth.userProperty] = {
       logged_in: false


### PR DESCRIPTION
### Motivation:

Changes to socket.io in v1.0.0 break the "latest" release of this module; these few minor revisions resolve the issue for me.   See the [Socket.io](https://github.com/LearnBoost/Socket.IO) [wiki](https://github.com/LearnBoost/Socket.IO/wiki) page [Migrating to 1.0](https://github.com/LearnBoost/socket.io/wiki/Migrating-to-1.0) for more details.
### Important updates to Socket.io:
- In v1, socket.io employs a middleware queue.
- authorization/authentication is now implemented as middleware. 
- middleware have two parameters: 
  1. `socket`, the `Socket` object, and 
  2. `next`, the next middleware function in the queue.
- `socket.handshake` is now `socket.request`
### Backward-Compatibility:

in v0.9.x, `data` is populated with `socket.handshake`, but in v1.0.x, it is populated with the socket itself.  Therefore, one can test for use of version 1.0 by checking whether the value of `data.request` is [truthy](http://james.padolsey.com/javascript/truthy-falsey/)
### Revisions in detail:
1. `next` is now called with no parameters on succes, and an Error on failure; updated `auth.success` and `auth.fail` to reflect. 
2. cookie headers will not be found at `data.headers.cookie` when using v1, created var `cookieHeader` for clarity.
