### PR TITLE
socketio v1 moved data.query to data._query

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,7 @@ function authorize(options) {
     }
 
     data.cookie = parseCookie(auth, data.headers.cookie || '');
-    data.sessionID = (data.query && data.query.session_id) || data.cookie[auth.key] || '';
+    data.sessionID = (data.query && data.query.session_id) || (data._query && data._query.session_id) || data.cookie[auth.key] || '';
     data[auth.userProperty] = {
       logged_in: false
     };


### PR DESCRIPTION
Hey there,  In addition to the changes you mention, socket.io v1 also moved the querystring parameter from data.query to data._query.  This pull request amends that, so scripted clients will work for "testing purposes" or what-have-you.

I think ideally you would create a new version of this library for socket.io v1, to make a clean break with the old syntax.  (Even more ideally, they would have called it socket.io v2 since the library has been around for like four years in its jaundiced "prerelease" state.)  Thanks for this module!
