### PR TITLE
Fixed issue when user id is 0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ function authorize(options) {
 
       var userKey = session[auth.passport._key][auth.userProperty];
 
-      if(!userKey)
+      if(typeof(userKey) === 'undefined')
         return auth.fail(data, 'User not authorized through passport. (User Property not found)', false, accept);
 
       auth.passport.deserializeUser(userKey, data, function(err, user) {


### PR DESCRIPTION
When user id is 0, so the serialized user is 0, passport.socketio fails to connect with the following error messgage: "User not authorized through passport. (User Property not found)".
It turned out that "if(!userKey)" evaulates to true, so passport.socketio thinks the user isn't authenticated.