### PR TITLE
Read correct key on session

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,7 +74,7 @@ function authorize(options) {
       if(!session[auth.passport._key])
         return auth.fail(data, 'Passport was not initialized', true, accept);
 
-      var userKey = session[auth.passport._key][auth.userProperty];
+      var userKey = session[auth.passport._key].user;
 
       if(typeof(userKey) === 'undefined')
         return auth.fail(data, 'User not authorized through passport. (User Property not found)', false, accept);


### PR DESCRIPTION
passport stores user information on the user key inside session.passport (session.passport.user), not on the value of userProperty (session.passport[userProperty]).

https://github.com/paramburu/passport/blob/master/lib/http/request.js#L55

I thought it made sense your approach but it seems it isn't going to change.

https://github.com/jaredhanson/passport/pull/474