### PR TITLE
Make passport dependency optional

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,6 @@ function parseCookie(auth, cookieHeader) {
 
 function authorize(options) {
   var defaults = {
-    passport:     require('passport'),
     key:          'connect.sid',
     secret:       null,
     store:        null,
@@ -39,6 +38,14 @@ function authorize(options) {
   };
 
   var auth = xtend(defaults, options);
+  
+  if(!auth.passport) {
+    try {
+      auth.passport = require('passport');
+    } catch (err) {
+      throw new Error('passport is required to use require(\'passport\'), please install passport');
+    }
+  }
 
   if (!auth.cookieParser) {
     try {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
   "dependencies": {
     "xtend": "^4.0.0"
   },
-  "peerDependencies": {
-    "passport": "~0.3.0"
-  },
   "devDependencies": {
     "body-parser": "~1.12.2",
     "connect": "~2.7.11",


### PR DESCRIPTION
This fixes #120.  Passport install is now optional.
