### PR TITLE
Add function filterSocketsByUserInNamespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,16 @@ passportSocketIo.filterSocketsByUser(io, function(user){
   socket.emit('messsage', 'hello, woman!');
 });
 ```
+### `passportSocketIo.filterSocketsByUserInNamespace`
+This function gives you the ability to filter all connected sockets in a certain namespace via a user property. Needs two parameters `function(nsp, function(user))`. Example:
+```javascript
+var nsp = io.of('/game')
+passportSocketIo.filterSocketsByUserInNamespace(nsp, function(user){
+  return user.gender === 'female';
+}).forEach(function(socket){
+  socket.emit('messsage', 'hello, woman!');
+});
+```
 
 ## CORS-Workaround:
 If you happen to have to work with Cross-Origin-Requests (marked by socket.io v0.9 as `handshake.xdomain` and by socket.io v1.0 as `request.xdomain`) then here's a workaround:

--- a/lib/index.js
+++ b/lib/index.js
@@ -114,5 +114,22 @@ function filterSocketsByUser(socketIo, filter){
     });
 }
 
+function filterSocketsByUserInNamespace(nsp, filter){
+  var handshaken = [];
+  for ( var i in nsp.connected )
+    if ( nsp.connected[i].handshake )
+        handshaken.push( nsp.connected[i] )
+
+  return Object.keys(handshaken || {})
+    .filter(function(skey){
+      return filter(handshaken[skey].conn.request.user);
+    })
+    .map(function(skey){
+      return handshaken[skey];
+    });
+}
+
 exports.authorize = authorize;
 exports.filterSocketsByUser = filterSocketsByUser;
+exports.filterSocketsByUserInNamespace = filterSocketsByUserInNamespace;
+


### PR DESCRIPTION
## Reason
I was trying to find sockets corresponding to certain users to join them to a room and then emit a mesagge to that room from the namespace, but this message was never received by the sockets. Creating this new function allow me to achieve this.

### Problem
```javascript
const nsp = io.of('/game')

nsp.on('connection', function(socket){
    let usersSockets = passportSocketIo.filterSocketsByUser(io, (user) => {
              return user._id == 'someId'
            })
    usersSockets.forEach((uSocket)=> {
         uSocket.join('room1')
    })
   nsp.to('room1').emit('joined', 'the game will start soon')
})
```
### Solution
```javascript
const nsp = io.of('/game')

nsp.on('connection', function(socket){
    let usersSockets = passportSocketIo.filterSocketsByUserInNamespace(nsp, (user) => {
              return user._id == 'someId'
            })
    usersSockets.forEach((uSocket)=> {
         uSocket.join('room1')
    })
   nsp.to('room1').emit('joined', 'the game will start soon')
})
```